### PR TITLE
Add macvlan network override example

### DIFF
--- a/docker-compose.macvlan.example.yml
+++ b/docker-compose.macvlan.example.yml
@@ -1,0 +1,37 @@
+# Macvlan Network Override Example
+# ============================================================
+# Use this to place the container on a macvlan network with a
+# static IP on your LAN. Useful for VLAN segmentation or when
+# you need the bot to appear as its own host on the network.
+#
+# Setup:
+#   1. Create the macvlan network (adjust parent/subnet for your LAN):
+#      docker network create -d macvlan \
+#        --subnet=192.168.1.0/24 \
+#        --gateway=192.168.1.1 \
+#        -o parent=eth0 \
+#        my-macvlan
+#
+#   2. Copy this file:
+#      cp docker-compose.macvlan.example.yml docker-compose.override.yml
+#
+#   3. Edit the IP address, DNS, and network name to match your setup.
+#
+#   4. Start normally — the override is picked up automatically:
+#      docker compose up -d
+#
+# Note: docker-compose.override.yml is gitignored so your local
+# config won't conflict with upstream updates.
+# ============================================================
+
+services:
+  boon-tube-daemon:
+    networks:
+      my-macvlan:
+        ipv4_address: 192.168.1.50
+    dns:
+      - 192.168.1.1
+
+networks:
+  my-macvlan:
+    external: true


### PR DESCRIPTION
Adds `docker-compose.macvlan.example.yml` for deploying the bot on a Docker macvlan network with a static LAN IP.

## What
- New file: `docker-compose.macvlan.example.yml`
- Provides a ready-to-use template for macvlan networking

## Usage
1. Create a macvlan Docker network on your host
2. Copy `docker-compose.macvlan.example.yml` to `docker-compose.override.yml`
3. Edit the IP address, DNS, and network name for your environment
4. Run `docker compose up -d` — the override is picked up automatically

## Why
Useful for VLAN-segmented setups where the container needs its own IP on the LAN, avoiding port-mapping conflicts and enabling direct network access.

This is optional — the default bridge networking continues to work as before.