### PR TITLE
chore(deps): apply pending Dependabot updates

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,7 +33,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -53,7 +53,7 @@ jobs:
         pytest tests/ -v --cov=boon_tube_daemon --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       if: matrix.python-version == '3.14'
       with:
         file: ./coverage.xml
@@ -69,7 +69,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,10 +30,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Review dependency changes
-      uses: actions/dependency-review-action@v4
+      uses: actions/dependency-review-action@v5
       with:
         fail-on-severity: moderate
         comment-summary-in-pr: true

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -28,7 +28,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -43,7 +43,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     
     - name: Set lowercase image name
       id: image-name

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -33,7 +33,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Snyk CLI
       uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04

--- a/docker/requirements-no-tiktok.txt
+++ b/docker/requirements-no-tiktok.txt
@@ -6,27 +6,27 @@ requests==2.33.1
 python-dateutil==2.9.0.post0
 
 # YouTube API
-google-api-python-client==2.193.0
-google-auth==2.49.1
+google-api-python-client==2.196.0
+google-auth==2.52.0
 google-auth-oauthlib==1.3.1
-google-auth-httplib2==0.3.1
+google-auth-httplib2==0.4.0
 
 # Social Media Platforms
-Mastodon.py==2.1.4
+Mastodon.py==2.2.1
 atproto==0.0.65  # Bluesky AT Protocol
 
 # Text Processing
 grapheme==0.6.0  # Unicode grapheme cluster counting (for Bluesky 300-grapheme limit)
 
 # Security: Pin protobuf to 5.x for compatibility with google-api-python-client
-protobuf>=5.29.6,<8.0.0
+protobuf>=7.34.1,<8.0.0
 
 # Configuration
 python-dotenv==1.2.2
 
 # LLM Integration
-google-genai>=1.65.0  # Google Gemini API (replaces deprecated google-generativeai)
-ollama==0.6.1  # Ollama local LLM (optional, for privacy-first AI)
+google-genai>=2.0.1  # Google Gemini API (replaces deprecated google-generativeai)
+ollama==0.6.2  # Ollama local LLM (optional, for privacy-first AI)
 
 # Secret Management (optional)
 doppler-sdk==1.3.0  # Doppler SDK for Python
@@ -34,6 +34,6 @@ doppler-sdk==1.3.0  # Doppler SDK for Python
 # Development/Testing (for CI/CD)
 pytest>=8.0.0
 pytest-cov>=4.1.0
-ruff>=0.1.0
+ruff>=0.15.12
 bandit>=1.7.0
 safety>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,27 +15,27 @@ requests==2.33.1
 python-dateutil==2.9.0.post0
 
 # YouTube API
-google-api-python-client==2.193.0
+google-api-python-client==2.196.0
 
 # TikTok monitoring via Playwright (no TikTokApi package needed) 
-playwright==1.58.0
+playwright==1.59.0
 
 # Social Media Platforms
-Mastodon.py==2.1.4
+Mastodon.py==2.2.1
 atproto==0.0.65  # Bluesky AT Protocol
 
 # Text Processing
 grapheme==0.6.0  # Unicode grapheme cluster counting (for Bluesky 300-grapheme limit)
 
 # Security: Pin protobuf to 5.x for compatibility with google-api-python-client
-protobuf>=5.29.6,<8.0.0
+protobuf>=7.34.1,<8.0.0
 
 # Configuration
 python-dotenv==1.2.2
 
 # LLM Integration
-google-genai>=1.65.0  # Google Gemini API (replaces deprecated google-generativeai)
-ollama==0.6.1  # Ollama local LLM (optional, for privacy-first AI)
+google-genai>=2.0.1  # Google Gemini API (replaces deprecated google-generativeai)
+ollama==0.6.2  # Ollama local LLM (optional, for privacy-first AI)
 
 # Secret Management (optional)
 doppler-sdk==1.3.0  # Doppler SDK for Python
@@ -43,8 +43,8 @@ doppler-sdk==1.3.0  # Doppler SDK for Python
 # HashiCorp Vault: hvac>=1.1.0
 
 # Development/Testing (for CI/CD)
-pytest==9.0.2
+pytest==9.0.3
 pytest-cov==7.1.0
-ruff==0.15.9
+ruff==0.15.12
 bandit==1.9.4
 safety==3.7.0


### PR DESCRIPTION
## Summary

Consolidates all currently-open **Dependabot** version bumps into a single PR, applied on top of the latest `main`. This supersedes the individual Dependabot PRs (they should auto-close once these versions land on `main`).

### pip (`requirements.txt` + `docker/requirements-no-tiktok.txt`)
| Package | From | To |
|---|---|---|
| google-api-python-client | 2.193.0 | 2.196.0 |
| google-auth | 2.49.1 | 2.52.0 |
| google-auth-httplib2 | 0.3.1 | 0.4.0 |
| Mastodon.py | 2.1.4 | 2.2.1 |
| playwright | 1.58.0 | 1.59.0 |
| protobuf | >=5.29.6,<8.0.0 | >=7.34.1,<8.0.0 |
| google-genai | >=1.65.0 | >=2.0.1 |
| ollama | 0.6.1 | 0.6.2 |
| pytest | 9.0.2 | 9.0.3 |
| ruff | 0.15.9 (docker floor 0.1.0) | 0.15.12 |

### github-actions
| Action | From | To |
|---|---|---|
| actions/checkout | v6 | v7 |
| actions/dependency-review-action | v4 | v5 |
| codecov/codecov-action | v5 | v7 |

## Note on the Snyk PRs

The 2 open **Snyk** PRs (`snyk-fix-*`) are **not** included and I recommend **closing them without merging**. They are branched from a much older `main` and merging them would regress the repo (~2,100 deletions: they revert `main.py`/`youtube_videos.py`/`bluesky.py`, delete `docker-compose.macvlan.example.yml` and `update.sh`, downgrade requests/playwright/atproto/python-dotenv/ruff/bandit, and revert `google-genai` back to the deprecated `google-generativeai`). Their only real intent — pinning protobuf against an advisory — is already satisfied by the `protobuf>=7.34.1` floor in this PR.
